### PR TITLE
Fix server issues, re-enable OTP verification, and update deployment configs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,23 @@
+# Server Configuration
+PORT=3000
+NODE_ENV=production
+FRONTEND_URL=https://your-frontend.vercel.app
+
+# Database
+# Note: For Render, you must use a MongoDB Atlas URI (cloud), not localhost
+MONGODB_URI=mongodb+srv://<username>:<password>@<cluster>.mongodb.net/spms
+
+# JWT Configuration
+JWT_SECRET=your_super_secret_jwt_key
+JWT_EXPIRES_IN=7d
+
+# Email Configuration
+# Required for OTP and Password Reset in production
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=587
+EMAIL_USER=your_email@gmail.com
+EMAIL_PASS=your_app_password
+EMAIL_FROM=your_email@gmail.com
+
+# Feature Flags
+ENABLE_SIGNUP_OTP=true

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -441,22 +441,22 @@ const signupStudent = async (req, res) => {
       });
     }
 
-    // Temporarily disable mandatory email OTP verification for signup
-    // if (OTP_SIGNUP_ENABLED) {
-    //   const latestOtp = await SignupOtp.findOne({
-    //     email: collegeEmail,
-    //     purpose: 'signup',
-    //     verified: true,
-    //   }).sort({ createdAt: -1 });
-    //
-    //   if (!latestOtp || latestOtp.expiresAt < new Date()) {
-    //     return res.status(400).json({
-    //       success: false,
-    //       message: 'Please verify the OTP sent to your email before creating an account',
-    //       errorCode: 'EMAIL_OTP_NOT_VERIFIED',
-    //     });
-    //   }
-    // }
+    // Mandatory email OTP verification for signup
+    if (OTP_SIGNUP_ENABLED) {
+      const latestOtp = await SignupOtp.findOne({
+        email: collegeEmail,
+        purpose: 'signup',
+        verified: true,
+      }).sort({ createdAt: -1 });
+    
+      if (!latestOtp || latestOtp.expiresAt < new Date()) {
+        return res.status(400).json({
+          success: false,
+          message: 'Please verify the OTP sent to your email before creating an account',
+          errorCode: 'EMAIL_OTP_NOT_VERIFIED',
+        });
+      }
+    }
 
     // Validate MIS number format (9 digits)
     if (!/^\d{9}$/.test(misNumber)) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "server.js",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,3 @@
-const dns = require('dns');
-dns.setServers(['8.8.8.8', '8.8.4.4']); 
 require("dotenv").config();
 const express = require('express');
 const cors = require('cors');
@@ -15,8 +13,6 @@ console.log = (...args) => {
   originalConsoleLog(...args);
 };
 
-require('dotenv').config({ debug: false, silent: true });
-
 // Import database connection
 const { connectDB } = require('./config/database');
 
@@ -30,7 +26,10 @@ const server = http.createServer(app);
 const PORT = process.env.PORT || 3000;
 
 // Middleware
-app.use(cors());
+app.use(cors({
+  origin: process.env.FRONTEND_URL || "http://localhost:5173",
+  credentials: true
+}));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,7 @@
+# API Configuration
+# In Vercel, set this to your Render backend URL (e.g., https://spms-api.onrender.com)
+VITE_API_URL=http://localhost:3000
+
+# Feature Flags
+# Set to 'false' to bypass OTP verification on the frontend during signup
+VITE_ENABLE_SIGNUP_OTP=true

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,9 +37,6 @@ import Sem8TrackFinalization from './pages/admin/Sem8TrackFinalization';
 import SystemConfiguration from './pages/admin/SystemConfiguration';
 import NotFound from './pages/NotFound';
 import AdminProfile from './pages/admin/Profile';
-import ToastDemo from './components/common/ToastDemo';
-import SignupTestDemo from './components/auth/SignupTestDemo';
-import SpecificErrorTestDemo from './components/auth/SpecificErrorTestDemo';
 import FacultyProfile from './pages/faculty/Profile';
 import StudentProfile from './pages/student/Profile';
 import Sem4ProjectDashboard from './pages/student/Sem4ProjectDashboard';
@@ -557,22 +554,7 @@ function AppContent() {
               <ProjectDetails />
             </ProtectedRoute>
           } />
-          {/* Demo Routes - Remove in production */}
-          <Route path="/toast-demo" element={
-            <Layout>
-              <ToastDemo />
-            </Layout>
-          } />
-          <Route path="/signup-test-demo" element={
-            <Layout>
-              <SignupTestDemo />
-            </Layout>
-          } />
-          <Route path="/specific-error-test-demo" element={
-            <Layout>
-              <SpecificErrorTestDemo />
-            </Layout>
-          } />
+          {/* Demo Routes - Removed for production */}
           <Route path="*" element={
             <Layout>
               <NotFound />

--- a/frontend/src/utils/websocket.js
+++ b/frontend/src/utils/websocket.js
@@ -17,7 +17,7 @@ class WebSocketManager {
     }
 
     try {
-      const wsUrl = process.env.VITE_WS_URL || 'ws://localhost:3000';
+      const wsUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
       this.socket = new WebSocket(`${wsUrl}?token=${token}`);
 
       this.socket.onopen = () => {

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
##  Feature: Production Deployment Preparation (Vercel & Render)

### Description
This PR introduces all the necessary configuration changes, security enforcements, and codebase cleanups required to deploy the Student Project Management System (SPMS) to production environments, specifically targeting **Vercel** (Frontend) and **Render** (Backend).

### Changes Made

#### Backend (Node.js/Express)
* **Server Configuration Fixes:** 
  * Removed hardcoded `dns.setServers()` which overrides DNS resolution and causes connectivity issues on cloud platforms like Render.
  * Replaced permissive `cors()` with origin-restricted CORS using the `FRONTEND_URL` environment variable to secure the API.
  * Cleaned up duplicate/redundant `dotenv` configurations.
* **Security & Auth:** Re-enabled mandatory OTP email verification for student signups (`authController.js`), which was previously bypassed for development testing.
* **Deployment Config:** Added `engines` field in `package.json` to explicitly specify Node.js `>=18.0.0` for the Render build environment.
* **Documentation:** Added `.env.example` to document all required environment variables (MongoDB Atlas URI, JWT config, SMTP credentials) needed for the Render dashboard.

#### Frontend (React/Vite)
* **Vercel SPA Routing:** Added `vercel.json` to handle React Router navigation correctly in production. This rewrites all routes to `index.html`, preventing `404 Not Found` errors upon page refresh.
* **Environment Variables:** Fixed `websocket.js` to use `import.meta.env.VITE_API_URL` instead of `process.env` (which is undefined in Vite builds).
* **Production Cleanup:** Removed development-only testing routes (`/toast-demo`, `/signup-test-demo`, etc.) and their unused component imports from `App.jsx` to keep the production bundle clean and secure.
* **Documentation:** Added `.env.example` detailing the required variables (`VITE_API_URL`, `VITE_ENABLE_SIGNUP_OTP`) for the Vercel dashboard.