### PR TITLE
fix(#84): remove unused bcrypt dependency and update import

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
@@ -23,6 +22,9 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -110,19 +112,6 @@
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
-      }
-    },
-    "node_modules/bcrypt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
-      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/bcryptjs": {
@@ -1201,24 +1190,6 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
-      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemailer": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",

--- a/backend/scripts/generatePasswordHash.js
+++ b/backend/scripts/generatePasswordHash.js
@@ -1,4 +1,4 @@
-const bcrypt = require('bcrypt');
+const bcrypt = require('bcryptjs');
 
 async function generateHash(password) {
   const salt = await bcrypt.genSalt(12);


### PR DESCRIPTION
## Summary
Resolves #84

Both `bcrypt` (native C++ addon) and `bcryptjs` (pure JavaScript) were
listed as dependencies, but only `bcryptjs` was used across the codebase.
Having both installed adds unnecessary compilation overhead and increases
the risk of platform-specific build failures without any functional benefit.

## Changes
- Removed `bcrypt` from `backend/package.json` and `backend/package-lock.json`
- Updated `backend/scripts/generatePasswordHash.js` to import `bcryptjs`
  instead of `bcrypt`, aligning it with the rest of the codebase

## Testing
- Verified all existing auth flows (login, registration, password reset)
  work correctly after the change
- Confirmed no remaining references to `bcrypt` exist in the backend

## Notes
No logic was changed — this is purely a dependency cleanup.

Fixes #84 