### PR TITLE
fix(#76): add helmet middleware for security headers

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.20.0",
         "mongoose": "^8.18.2",
@@ -23,6 +24,9 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -734,6 +738,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.20.0",
     "mongoose": "^8.18.2",

--- a/backend/server.js
+++ b/backend/server.js
@@ -8,6 +8,7 @@ if (dns.setDefaultResultOrder) {
 
 const express = require('express');
 const cors = require('cors');
+const helmet = require('helmet');
 const http = require('http');
 const SocketService = require('./services/socketService');
 
@@ -33,6 +34,7 @@ const server = http.createServer(app);
 const PORT = process.env.PORT || 3000;
 
 // Middleware
+app.use(helmet());
 app.use(cors({
   origin: process.env.FRONTEND_URL || "http://localhost:5173",
   credentials: true


### PR DESCRIPTION
## What does this PR do?
Adds `helmet` middleware to the Express server to set essential HTTP security
headers, protecting the application against clickjacking, MIME-sniffing, and
XSS attacks.

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Security fix
- [ ] Docs / config

## Testing
- Manually verified the server starts without errors after adding helmet
- Confirmed security headers (`X-Frame-Options`, `X-Content-Type-Options`,
  `Strict-Transport-Security`, `Content-Security-Policy`) are present in
  HTTP responses using browser DevTools / Postman

## Notes for reviewer
Helmet is added with default configuration which is safe for most Express
apps. If any frontend features break due to `Content-Security-Policy`
restrictions, CSP can be configured or relaxed per route as a follow-up.

Fixes #76