### PR TITLE
fix(auth): hash OTPs before storage and use bcryptjs.compare for veri…

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -239,10 +239,13 @@ const sendSignupOtp = async (req, res) => {
       }
     }
 
+    // Hash OTP using bcryptjs before storing in database
+    const hashedOtp = await bcrypt.hash(otp, 10);
+
     // Create OTP record if email was sent successfully OR in development mode
     await SignupOtp.create({
       email,
-      otp,
+      otp: hashedOtp,
       purpose: 'signup',
       expiresAt,
     });
@@ -301,7 +304,9 @@ const verifySignupOtp = async (req, res) => {
       });
     }
 
-    if (record.otp !== otp) {
+    // Verify OTP using bcryptjs.compare
+    const isValidOtp = await bcrypt.compare(otp, record.otp);
+    if (!isValidOtp) {
       return res.status(400).json({
         success: false,
         message: 'Invalid OTP. Please try again.',


### PR DESCRIPTION
## What does this PR do?
This PR hashes email verification OTPs using bcryptjs before storing them 
in MongoDB, and validates user submissions using bcrypt.compare. This fixes 
a security vulnerability where active OTPs were stored as plaintext.

## Type of change
- [x] Bug fix
- [x] Security fix

## Testing
- Verified OTP is stored as a bcrypt hash string starting with $2b$
- Verified invalid OTP inputs are rejected with 400 status
- Verified correct OTP inputs pass validation with 200 status

## Notes for reviewer
- Uses existing bcryptjs dependency already imported in authController.js
- No schema changes needed — otp field is already defined as String