### PR TITLE
Fix/submission window fail open

### DIFF
--- a/backend/middleware/windowCheck.js
+++ b/backend/middleware/windowCheck.js
@@ -55,9 +55,12 @@ const checkWindow = (configKey, allowIfNull = true) => {
       next();
     } catch (error) {
       console.error('Window check error:', error);
-      // On error, allow operation (fail open) to avoid blocking legitimate requests
-      // Admin can always override via direct database/config access
-      next();
+      // Fail closed on database/server errors
+      return res.status(503).json({
+        success: false,
+        message: 'Database connection failed. Try again later',
+        error: error.message
+      });
     }
   };
 };
@@ -97,6 +100,7 @@ const isWindowOpen = async (configKey) => {
       };
     }
 
+    // Window is open, return true
     return {
       isOpen: true,
       start: startDate,
@@ -104,8 +108,11 @@ const isWindowOpen = async (configKey) => {
     };
   } catch (error) {
     console.error('isWindowOpen error:', error);
-    // Default to open on error
-    return { isOpen: true, reason: 'Error checking window' };
+    // Fail closed on database/server errors
+    return { 
+      isOpen: false, 
+      reason: 'Database connection failed. Try again later' 
+    };
   }
 };
 

--- a/frontend/src/utils/toast.js
+++ b/frontend/src/utils/toast.js
@@ -142,6 +142,7 @@ export const toastMessages = {
   updateSuccess: 'Updated successfully!',
   genericError: 'Something went wrong. Please try again.',
   networkError: 'Network error. Please check your connection.',
+  dbConnectionError: 'Database connection failed. Try again later',
   unauthorized: 'You are not authorized to perform this action.',
   validationError: 'Please check the form for errors.',
 };


### PR DESCRIPTION
## What does this PR do?

This PR hardens the system's time-gated operation controls by modifying the `checkWindow` middleware and `isWindowOpen` helper to "fail-closed" on database outages or server connection errors. It now returns an HTTP `503 Service Unavailable` status instead of calling `next()`, preventing users from bypassing operation deadlines during database downtime.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Security fix
- [ ] Docs / config

## Testing

- **Manual Testing**: Verified using a database outage simulation test script ([test-window-check-error.js](file:///C:/Users/rishi/.gemini/antigravity/brain/25cfa7f4-e015-47ab-8f9c-cfa82080c171/scratch/test-window-check-error.js)):
  - Verified that `isWindowOpen` returns `isOpen: false` with the reason `'Database connection failed. Try again later'`.
  - Verified that `checkWindow` middleware responds with status `503`, returns the failure message, and does **not** call `next()`, successfully blocking access.

## Notes for reviewer

This security hardening protects all operations governed by time-gated windows:
* **Group Registration / Formation**: Creating, joining, or finalizing groups (Sem 5, B.Tech Sem 7, B.Tech Sem 8).
* **Faculty Preference Selection**: Submitting or ranking preferences (Sem 5, B.Tech Sem 7, B.Tech Sem 8).
* **Internship Registrations**: Applying for B.Tech Sem 7 Internship 1 or Sem 8 Internship 2.
* **Internship Evidence Uploads**: Uploading evidence files for B.Tech Sem 7/8 internships.
* **Semester Track Choices**: Submitting/updating track selection for B.Tech Sem 7/8 and M.Tech Sem 3.

### Commits in this PR:
1. `fix(middleware): implement fail-closed error handling in submission window check` — Updates catch blocks in [windowCheck.js](file:///d:/Student-MAnagement-IIITP-Fork/Student-Project-Management-System-IIITP-2/backend/middleware/windowCheck.js) to deny access (fail-closed) and return `503` when database queries fail.
2. `fix(ui): add error toast for service unavailable response` — Registers the `dbConnectionError` fallback key to `toastMessages` in [toast.js](file:///d:/Student-MAnagement-IIITP-Fork/Student-Project-Management-System-IIITP-2/frontend/src/utils/toast.js) to handle the UI styling for this response.