### PR TITLE
Fix #75: Add rate limiting to authentication endpoints

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.20.0",
@@ -571,6 +572,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -787,6 +806,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.20.0",

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -16,16 +16,41 @@ const {
   resetPassword,
 } = require('../controllers/authController');
 const { authenticateToken } = require('../middleware/auth');
+const rateLimit = require('express-rate-limit');
+
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: { success: false, message: 'Too many login attempts. Please try again after 15 minutes.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const otpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: { success: false, message: 'Too many OTP attempts. Please try again after 15 minutes.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const passwordResetLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: { success: false, message: 'Too many password reset attempts. Please try again after 1 hour.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Public routes (no authentication required)
 router.post('/signup/student', signupStudent);
 router.post('/signup/faculty', signupFaculty);
 router.post('/signup/admin', signupAdmin);
-router.post('/signup/send-otp', sendSignupOtp);
-router.post('/signup/verify-otp', verifySignupOtp);
-router.post('/forgot-password', requestPasswordReset);
-router.post('/reset-password', resetPassword);
-router.post('/login', loginUser);
+router.post('/signup/send-otp', otpLimiter, sendSignupOtp);
+router.post('/signup/verify-otp', otpLimiter, verifySignupOtp);
+router.post('/forgot-password', passwordResetLimiter, requestPasswordReset);
+router.post('/reset-password', passwordResetLimiter, resetPassword);
+router.post('/login', loginLimiter, loginUser);
 router.post('/logout', logoutUser);
 
 


### PR DESCRIPTION
Fixes #75

### Changes

* Added rate limiting to authentication endpoints using `express-rate-limit`.
* Protected login, OTP generation, OTP verification, forgot password, and reset password routes from brute-force attacks.

### Limits

* Login: 10 attempts per 15 minutes
* Send OTP: 5 attempts per 15 minutes
* Verify OTP: 5 attempts per 15 minutes
* Forgot Password: 5 attempts per hour
* Reset Password: 5 attempts per hour

### Testing

* Verified login requests are blocked after the configured limit.
* Verified OTP verification requests are blocked after the configured limit.
* Confirmed normal authentication flows continue to work correctly.
