### PR TITLE
Parallelize database queries in dashboard controllers

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -148,55 +148,62 @@ const updateAdminProfile = async (req, res) => {
 // Get admin dashboard data
 const getDashboardData = async (req, res) => {
   try {
-    // Get basic counts
-    const totalStudents = await Student.countDocuments();
-    const totalFaculty = await Faculty.countDocuments();
-    const totalUsers = await User.countDocuments();
-    const totalProjects = await Project.countDocuments();
-    const totalGroups = await Group.countDocuments();
 
-    // Get project statistics
-    const projectStats = {
-      total: totalProjects,
-      registered: await Project.countDocuments({ status: 'registered' }),
-      faculty_allocated: await Project.countDocuments({ status: 'faculty_allocated' }),
-      active: await Project.countDocuments({ status: 'active' }),
-      completed: await Project.countDocuments({ status: 'completed' }),
-      cancelled: await Project.countDocuments({ status: 'cancelled' })
-    };
+    // ── Wave 1: All independent count queries in parallel (17 queries) ──
+    const [
+      totalStudents,
+      totalFaculty,
+      totalUsers,
+      totalProjects,
+      totalGroups,
+      registeredProjects,
+      facultyAllocatedProjects,
+      activeProjects,
+      completedProjects,
+      cancelledProjects,
+      formingGroups,
+      completeGroups,
+      lockedGroups,
+      disbandedGroups,
+      pendingAllocations,
+      allocatedPreferences,
+      rejectedPreferences
+    ] = await Promise.all([
+      Student.countDocuments(),
+      Faculty.countDocuments(),
+      User.countDocuments(),
+      Project.countDocuments(),
+      Group.countDocuments(),
+      Project.countDocuments({ status: 'registered' }),
+      Project.countDocuments({ status: 'faculty_allocated' }),
+      Project.countDocuments({ status: 'active' }),
+      Project.countDocuments({ status: 'completed' }),
+      Project.countDocuments({ status: 'cancelled' }),
+      Group.countDocuments({ status: 'forming' }),
+      Group.countDocuments({ status: 'complete' }),
+      Group.countDocuments({ status: 'locked' }),
+      Group.countDocuments({ status: 'disbanded' }),
+      FacultyPreference.countDocuments({ status: { $in: ['pending', 'pending_admin_allocation'] } }),
+      FacultyPreference.countDocuments({ status: 'allocated' }),
+      FacultyPreference.countDocuments({ status: 'rejected' })
+    ]);
 
-    // Get group statistics
-    const groupStats = {
-      total: totalGroups,
-      forming: await Group.countDocuments({ status: 'forming' }),
-      complete: await Group.countDocuments({ status: 'complete' }),
-      locked: await Group.countDocuments({ status: 'locked' }),
-      disbanded: await Group.countDocuments({ status: 'disbanded' })
-    };
-
-    // Get allocation statistics
-    const allocationStats = {
-      pending: await FacultyPreference.countDocuments({ status: { $in: ['pending', 'pending_admin_allocation'] } }),
-      allocated: await FacultyPreference.countDocuments({ status: 'allocated' }),
-      rejected: await FacultyPreference.countDocuments({ status: 'rejected' })
-    };
-
-    // Get recent activities
-    const recentStudents = await Student.find()
-      .populate('user', 'email role isActive lastLogin')
-      .sort({ createdAt: -1 })
-      .limit(5);
-
-    const recentFaculty = await Faculty.find()
-      .populate('user', 'email role isActive lastLogin')
-      .sort({ createdAt: -1 })
-      .limit(5);
-
-    const recentProjects = await Project.find()
-      .populate('student', 'fullName misNumber')
-      .populate('faculty', 'fullName department')
-      .sort({ createdAt: -1 })
-      .limit(5);
+    // ── Wave 2: Recent activity queries in parallel (3 queries) ──
+    const [recentStudents, recentFaculty, recentProjects] = await Promise.all([
+      Student.find()
+        .populate('user', 'email role isActive lastLogin')
+        .sort({ createdAt: -1 })
+        .limit(5),
+      Faculty.find()
+        .populate('user', 'email role isActive lastLogin')
+        .sort({ createdAt: -1 })
+        .limit(5),
+      Project.find()
+        .populate('student', 'fullName misNumber')
+        .populate('faculty', 'fullName department')
+        .sort({ createdAt: -1 })
+        .limit(5)
+    ]);
 
     res.json({
       success: true,
@@ -208,9 +215,26 @@ const getDashboardData = async (req, res) => {
           totalProjects,
           totalGroups
         },
-        projectStats,
-        groupStats,
-        allocationStats,
+        projectStats: {
+          total: totalProjects,
+          registered: registeredProjects,
+          faculty_allocated: facultyAllocatedProjects,
+          active: activeProjects,
+          completed: completedProjects,
+          cancelled: cancelledProjects
+        },
+        groupStats: {
+          total: totalGroups,
+          forming: formingGroups,
+          complete: completeGroups,
+          locked: lockedGroups,
+          disbanded: disbandedGroups
+        },
+        allocationStats: {
+          pending: pendingAllocations,
+          allocated: allocatedPreferences,
+          rejected: rejectedPreferences
+        },
         recentStudents,
         recentFaculty,
         recentProjects

--- a/backend/controllers/facultyController.js
+++ b/backend/controllers/facultyController.js
@@ -256,7 +256,7 @@ const getDashboardData = async (req, res) => {
   try {
     const facultyId = req.user.id;
 
-    // Get faculty details
+    // Get faculty details (must run first — other queries depend on faculty._id)
     const faculty = await Faculty.findOne({ user: facultyId })
       .populate('user', 'email role isActive lastLogin');
 
@@ -267,33 +267,36 @@ const getDashboardData = async (req, res) => {
       });
     }
 
-    // Get faculty's assigned projects
-    const assignedProjects = await Project.find({
-      faculty: faculty._id,
-      status: { $in: ['faculty_allocated', 'active', 'completed'] }
-    })
-      .populate('student', 'fullName misNumber collegeEmail semester degree branch')
-      .populate('group', 'name members')
-      .sort({ createdAt: -1 });
+    // ── Parallelize 3 independent queries that depend on faculty._id ──
+    const [assignedProjects, assignedGroups, pendingAllocations] = await Promise.all([
+      // Get faculty's assigned projects
+      Project.find({
+        faculty: faculty._id,
+        status: { $in: ['faculty_allocated', 'active', 'completed'] }
+      })
+        .populate('student', 'fullName misNumber collegeEmail semester degree branch')
+        .populate('group', 'name members')
+        .sort({ createdAt: -1 }),
 
-    // Get faculty's assigned groups
-    const assignedGroups = await Group.find({
-      allocatedFaculty: faculty._id,
-      isActive: true
-    })
-      .populate('members.student', 'fullName misNumber collegeEmail')
-      .populate('project', 'title description projectType status')
-      .sort({ createdAt: -1 });
+      // Get faculty's assigned groups
+      Group.find({
+        allocatedFaculty: faculty._id,
+        isActive: true
+      })
+        .populate('members.student', 'fullName misNumber collegeEmail')
+        .populate('project', 'title description projectType status')
+        .sort({ createdAt: -1 }),
 
-    // Get pending allocation requests
-    const pendingAllocations = await FacultyPreference.find({
-      'preferences.faculty': faculty._id,
-      status: 'pending'
-    })
-      .populate('student', 'fullName misNumber collegeEmail semester degree branch')
-      .populate('project', 'title description projectType')
-      .populate('group', 'name members')
-      .sort({ createdAt: 1 });
+      // Get pending allocation requests
+      FacultyPreference.find({
+        'preferences.faculty': faculty._id,
+        status: 'pending'
+      })
+        .populate('student', 'fullName misNumber collegeEmail semester degree branch')
+        .populate('project', 'title description projectType')
+        .populate('group', 'name members')
+        .sort({ createdAt: 1 })
+    ]);
 
     // Get faculty statistics
     const stats = {

--- a/backend/controllers/studentController.js
+++ b/backend/controllers/studentController.js
@@ -15,7 +15,7 @@ const getDashboardData = async (req, res) => {
   try {
     const studentId = req.user.id;
 
-    // Get student details with populated data
+    // Get student details with populated data (must run first — other queries depend on student)
     const student = await Student.findOne({ user: studentId })
       .populate('user', 'email role isActive lastLogin')
       .populate('currentProjects.project')
@@ -38,15 +38,24 @@ const getDashboardData = async (req, res) => {
       projectCapabilities[projectType] = supportsGroupsAndFaculty(projectType, student.semester, student.degree);
     });
 
-    // Get active group memberships first
-    const activeGroups = await Group.find({
-      'members.student': student._id,
-      'members.isActive': true,
-      semester: student.semester,
-      isActive: true
-    }).populate('members.student allocatedFaculty project');
+    // ── Parallelize: activeGroups and facultyPreferences are independent ──
+    const [activeGroups, facultyPreferences] = await Promise.all([
+      // Get active group memberships
+      Group.find({
+        'members.student': student._id,
+        'members.isActive': true,
+        semester: student.semester,
+        isActive: true
+      }).populate('members.student allocatedFaculty project'),
 
-    // Get current semester projects
+      // Get faculty preferences for current semester
+      FacultyPreference.find({
+        student: student._id,
+        semester: student.semester
+      }).populate('project group preferences.faculty')
+    ]);
+
+    // Get current semester projects (depends on activeGroups for groupIds)
     // Include projects where:
     // 1. Student is the direct owner (for solo projects)
     // 2. Student is in a group that has the project (for group projects)
@@ -59,12 +68,6 @@ const getDashboardData = async (req, res) => {
         { group: { $in: groupIds } } // Group membership
       ]
     }).populate('faculty group');
-
-    // Get faculty preferences for current semester (only if project type supports faculty preferences)
-    const facultyPreferences = await FacultyPreference.find({
-      student: student._id,
-      semester: student.semester
-    }).populate('project group preferences.faculty');
 
     // Use the enhanced student model's dashboard data method
     const dashboardData = student.getDashboardData();


### PR DESCRIPTION
## What does this PR do?

Refactors the dashboard controllers (admin, faculty, student) to use `Promise.all()` for independent database queries instead of executing them sequentially. The admin dashboard in particular was running 20 blocking queries in a row, causing unnecessary latency.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Security fix
- [ ] Docs / config

## Testing

Wrote a custom latency benchmark script (`backend/scripts/benchmark.js`). Measured roundtrip time locally before and after the change, showing a massive drop in latency. Also verified manually that the dashboard UI still loads perfectly across all three roles since the API response structure is 100% identical.
Before refactor 
<img width="514" height="249" alt="image" src="https://github.com/user-attachments/assets/2748d1d7-ec19-4652-83ef-d69fa4fbf747" />

After refactor
<img width="512" height="251" alt="image" src="https://github.com/user-attachments/assets/5ab37e51-81e8-4897-b488-2d41481ca3a6" />


## Notes for reviewer

This is a backend-only drop-in optimization. The JSON response shape hasn't changed at all, so zero frontend changes are required. 

## Fixes
Fixes #105
