### PR TITLE
feat: add keep-alive workaround for render free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ frontend/
 - `routes/` - API endpoint definitions
 - `middleware/` - Authentication, validation, file uploads
 - `services/` - Email and Socket.IO services
+- `keepalive/` - Temporary workaround to prevent sleeping on Render free tier (see `backend/keepalive/README.md`)
 
 **Frontend:**
 - `pages/student/` - Student-specific pages (25+ pages)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,8 @@ EMAIL_FROM=your_email@gmail.com
 
 # Feature Flags
 ENABLE_SIGNUP_OTP=true
+
+# TEMPORARY WORKAROUND: Keep-alive for Render free tier.
+# Set to true to enable the /api/health endpoint for UptimeRobot.
+# Remember to remove this when upgrading to a paid plan.
+KEEP_ALIVE_ENABLED=true

--- a/backend/keepalive/README.md
+++ b/backend/keepalive/README.md
@@ -1,0 +1,26 @@
+# Keep-Alive Module
+
+**TEMPORARY WORKAROUND**
+
+## What it does
+This module provides a lightweight `/api/health` endpoint that returns a `200 OK` and the server uptime. It is intended to be pinged regularly (e.g., every 5 minutes by UptimeRobot) to prevent the backend from sleeping on Render's free tier, which spins down services after 15 minutes of inactivity. 
+
+## Why it exists
+Render's free tier puts applications to sleep. This workaround keeps the service warm to avoid cold start delays for users.
+
+## Removal Steps
+When the backend is upgraded to a paid Render plan that doesn't sleep, this module is no longer needed and should be cleanly removed. 
+
+1. **Delete this entire folder**: `backend/keepalive/`
+2. **Remove the route in `server.js`**:
+   Remove the following lines from `backend/server.js`:
+   ```javascript
+   // Keep-alive route (temporary for Render free tier)
+   if (process.env.KEEP_ALIVE_ENABLED === 'true') {
+     const { createKeepAliveRouter } = require('./keepalive');
+     app.use('/api/health', createKeepAliveRouter());
+   }
+   ```
+3. **Unset the environment variable**: 
+   Remove `KEEP_ALIVE_ENABLED` from your `.env` and `.env.example` files on all environments.
+4. **Delete UptimeRobot monitor**: Log in to UptimeRobot (or whatever monitoring service you're using) and delete the monitor hitting this endpoint.

--- a/backend/keepalive/index.js
+++ b/backend/keepalive/index.js
@@ -1,0 +1,32 @@
+/**
+ * TEMPORARY: Remove when Render is upgraded to a paid/always-on plan.
+ * See README.md in this folder for removal steps.
+ */
+
+const express = require('express');
+
+const createKeepAliveRouter = () => {
+  const router = express.Router();
+
+  router.get('/', (req, res) => {
+    const userAgent = req.get('User-Agent') || '';
+    
+    // Distinguish traffic from UptimeRobot
+    if (userAgent.includes('UptimeRobot')) {
+      console.log('[keepalive] Ping received from UptimeRobot');
+    } else {
+      console.log(`[keepalive] Ping received from ${userAgent || 'unknown'}`);
+    }
+
+    res.status(200).json({
+      status: 'ok',
+      uptime: process.uptime()
+    });
+  });
+
+  return router;
+};
+
+module.exports = {
+  createKeepAliveRouter
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -44,6 +44,12 @@ app.use(express.urlencoded({ extended: true }));
 
 
 // Routes
+// Keep-alive route (temporary for Render free tier)
+if (process.env.KEEP_ALIVE_ENABLED === 'true') {
+  const { createKeepAliveRouter } = require('./keepalive');
+  app.use('/api/health', createKeepAliveRouter());
+}
+
 app.use('/', indexRoutes);
 
 // Error handling middleware (must be last)


### PR DESCRIPTION
## What does this PR do?
Introduced /health api for uptimerobot to ping
<!-- One or two sentences. What changed and why. -->

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Security fix
- [x] Docs / config

## Testing

<!-- How did you verify this works? Manual testing, unit tests, nothing yet? -->

## Notes for reviewer

<!-- Anything that needs context — tricky logic, known limitations, follow-up work. Omit if nothing to add. -->

<!-- Write the issue that you pr refers. -->
